### PR TITLE
05 auto size tooltip

### DIFF
--- a/Circuit Simulator/Assets/Prefabs/ToolTip.prefab
+++ b/Circuit Simulator/Assets/Prefabs/ToolTip.prefab
@@ -234,7 +234,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
   m_textAlignment: 65535

--- a/Circuit Simulator/Assets/Scripts/Tooltip.cs
+++ b/Circuit Simulator/Assets/Scripts/Tooltip.cs
@@ -9,7 +9,7 @@ public class Tooltip : MonoBehaviour
     public Camera cam;
     private Vector3 min, max;
     private RectTransform rect;
-    private float offset = 3f;
+    private float offset = 1f;
 
     public string name, volts, amps, fault;
     public TMP_Text namebox, vbox, abox, fbox;
@@ -38,7 +38,7 @@ public class Tooltip : MonoBehaviour
         if (gameObject.activeSelf)
         {
             //get the tooltip position with offset
-            Vector3 position = new Vector3(Input.mousePosition.x + rect.rect.width, Input.mousePosition.y - (rect.rect.height / 2 + offset), 0f);
+            Vector3 position = new Vector3(Input.mousePosition.x + (rect.rect.width / 4) + offset, Input.mousePosition.y - (rect.rect.height / 4) - offset, 0f);
             //clamp it to the screen size so it doesn't go outside
             transform.position = new Vector3(Mathf.Clamp(position.x, min.x + rect.rect.width/2, max.x - rect.rect.width/2), Mathf.Clamp(position.y, min.y + rect.rect.height / 2, max.y - rect.rect.height / 2), transform.position.z);
         }


### PR DESCRIPTION
Tooltip is now content aware, and will scale based on the width of its text elements. It is also now more correctly positioned near the cursor. "Name:" has been removed from the tooltip, in favor of bolding the text field.